### PR TITLE
Fix special character in config.py

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -68,7 +68,7 @@ class ConfigTab(object):
         )
         self.xdelta = BoundedFloatText(
             min=1.,
-            description='dx',   # '∆x',  # Mac: opt-j for delta
+            description='dx',   # 'dx',  # Mac: opt-j for delta
             disabled = disable_domain,
             layout=Layout(width=constWidth),
         )


### PR DESCRIPTION
There's a Non-ASCII character in config.py, which gives an error on my system (ubuntu 18) : 
`
SyntaxError: Non-ASCII character '\xe2' in file PhysiCell-Jupyter-GUI/Example_GUIs/pc4biorobots/bin/config.py on line 71, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`